### PR TITLE
Allow to override build date with SOURCE_DATE_EPOCH

### DIFF
--- a/branding/Makefile.in
+++ b/branding/Makefile.in
@@ -60,7 +60,7 @@ $(BINDIR)/%.png: \
 
 	@echo $@ ...
 	@$(MKDIR) `dirname $@`
-	@$(CONVERT) -background transparent $< $@
+	@$(CONVERT) -strip -background transparent $< $@
 	@$(OPTIPNG) -o7 $@
 
 $(BINDIR)/%.ico: \

--- a/src/libpw3270cpp/Makefile.in
+++ b/src/libpw3270cpp/Makefile.in
@@ -61,6 +61,13 @@ VALGRIND=@VALGRIND@
 INSTALL_DATA=@INSTALL_DATA@
 INSTALL_PROGRAM=@INSTALL_PROGRAM@
 
+DATE_FMT = +%Y%m%d
+ifdef SOURCE_DATE_EPOCH
+    BUILD_DATE ?= $(shell date -u -d "@$(SOURCE_DATE_EPOCH)" "$(DATE_FMT)" 2>/dev/null || date -u -r "$(SOURCE_DATE_EPOCH)" "$(DATE_FMT)" 2>/dev/null || date -u "$(DATE_FMT)")
+else
+    BUILD_DATE ?= $(shell date "$(DATE_FMT)")
+endif
+
 CFLAGS= \
 	@CFLAGS@ \
 	-Wno-deprecated-declarations \
@@ -102,7 +109,7 @@ $(OBJRLS)/%.o: \
 	@$(MKDIR) `dirname $@`
 	@$(CC) $(CFLAGS) \
 		@RLS_CFLAGS@ \
-		-DBUILD_DATE=`date +"%Y%m%d"` \
+		-DBUILD_DATE=$(BUILD_DATE) \
 		-o $@ -c $<
 
 $(POTDIR)/%.pot: %.c


### PR DESCRIPTION
Allow to override build date with `SOURCE_DATE_EPOCH`
in order to make builds reproducible.
See https://reproducible-builds.org/ for why this is good
and https://reproducible-builds.org/specs/source-date-epoch/
for the definition of this variable.

Also switch to UTC to be independent of timezone.

Note: This date call is designed to work with different flavors
of date (GNU, BSD and others).
If only GNU (Linux) support is needed, the patch can be simplified.

This PR was done while working on reproducible builds for openSUSE.