### PR TITLE
Convert from appdata to metainfo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,7 +57,7 @@ src/include/lib3270
 vgcore.*
 gschemas.compiled
 *.gschema.xml
-appdata.xml
+metainfo.xml
 *.metainfo.xml
 
 *.[0-9]

--- a/branding/Makefile.in
+++ b/branding/Makefile.in
@@ -101,7 +101,7 @@ endif
 validate:
 
 ifneq ($(SCOUR),no)
-	@$(APPSTREAMCLI) validate appdata.xml
+	@$(APPSTREAMCLI) validate metainfo.xml
 endif
 
 
@@ -128,10 +128,10 @@ install-linux: \
 		mime.xml \
 		$(DESTDIR)$(datarootdir)/mime/packages/$(PRODUCT_NAME).xml
 
-	@$(MKDIR) $(DESTDIR)$(datarootdir)/appdata
+	@$(MKDIR) $(DESTDIR)$(datarootdir)/metainfo
 	@$(INSTALL_DATA) \
-		appdata.xml \
-		$(DESTDIR)$(datarootdir)/appdata/$(APPLICATION_ID).appdata.xml
+		metainfo.xml \
+		$(DESTDIR)$(datarootdir)/metainfo/$(APPLICATION_ID).metainfo.xml
 
 	@$(MKDIR) $(DESTDIR)$(datarootdir)/icons/hicolor/scalable/apps
 	@$(INSTALL_DATA) \

--- a/branding/metainfo.xml.in
+++ b/branding/metainfo.xml.in
@@ -2,7 +2,7 @@
 
 <!--
 
-	References: 
+	References:
 
 		https://www.freedesktop.org/software/appstream/docs/chap-Quickstart.html#sect-Quickstart-DesktopApps
 		https://people.freedesktop.org/~hughsient/temp/AppData_WhitePaper.pdf
@@ -10,12 +10,13 @@
 
 -->
 
-<component type="desktop">
+<component type="desktop-application">
 
-	<id>@APPLICATION_ID@.desktop</id>
+	<id>@APPLICATION_ID@</id>
 
 	<metadata_license>CC0-1.0</metadata_license>
 	<project_license>LGPL-3.0</project_license>
+	<content_rating type="oars-1.1" />
 
 	<name>@PRODUCT_NAME@</name>
 	<name xml:lang="pt_BR">@PRODUCT_NAME@</name>
@@ -40,6 +41,8 @@
 	<url type="homepage">https://github.com/PerryWerneck/pw3270</url>
 	<url type="bugtracker">https://github.com/PerryWerneck/pw3270/issues</url>
 
+	<launchable type="desktop-id">@APPLICATION_ID@.desktop</launchable>
+
 	<screenshots>
 		<screenshot type="default">
 			<caption>Acessing MVS with @PRODUCT_NAME@</caption>
@@ -50,12 +53,13 @@
 
 	<update_contact>perry.werneck@gmail.com</update_contact>
 
-	<project_group>GNOME</project_group>
-
 	<provides>
 		<binary>@PRODUCT_NAME@</binary>
 	</provides>
 
 	<translation type="gettext">@PRODUCT_NAME@</translation>
 
+	<releases>
+		<release version="@VERSION@"/>
+	</releases>
 </component>

--- a/configure.ac
+++ b/configure.ac
@@ -279,7 +279,7 @@ AC_CONFIG_FILES(locale/Makefile)
 AC_CONFIG_FILES(branding/Makefile)
 AC_CONFIG_FILES(branding/launcher.desktop)
 AC_CONFIG_FILES(branding/mime.xml)
-AC_CONFIG_FILES(branding/appdata.xml)
+AC_CONFIG_FILES(branding/metainfo.xml)
 dnl AC_CONFIG_FILES(branding/keypad.metainfo.xml)
 
 dnl ---------------------------------------------------------------------------

--- a/rpm/pw3270.spec
+++ b/rpm/pw3270.spec
@@ -142,7 +142,7 @@ make all -j1
 
 %find_lang pw3270 langfiles
 
-appstream-util validate-relax --nonet %{buildroot}%{_datadir}/appdata/*.appdata.xml
+appstream-util validate-relax --nonet %{buildroot}%{_datadir}/metainfo/*.metainfo.xml
 
 %fdupes %{buildroot}/%{_prefix}
 
@@ -162,7 +162,7 @@ appstream-util validate-relax --nonet %{buildroot}%{_datadir}/appdata/*.appdata.
 
 # Desktop files
 %{_datadir}/applications/*.desktop
-%{_datadir}/appdata/*.appdata.xml
+%{_datadir}/metainfo/*.metainfo.xml
 
 # Icons
 %{_datadir}/%{_product}/icons/*.svg

--- a/validate-appdata.sh
+++ b/validate-appdata.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-./configure
-
-cp branding/appdata.xml /tmp/pw3270.appdata.xml
-appstream-util validate /tmp/pw3270.appdata.xml
-

--- a/validate-metainfo.sh
+++ b/validate-metainfo.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+./configure
+
+cp branding/metainfo.xml /tmp/pw3270.metainfo.xml
+appstream-util validate /tmp/pw3270.metainfo.xml
+


### PR DESCRIPTION
According to https://docs.fedoraproject.org/en-US/packaging-guidelines/AppData/ GUI applications should install metainfo files instead of appdata. Convert to the new format.